### PR TITLE
Add ORCID for Robert Court

### DIFF
--- a/.zenodo.json
+++ b/.zenodo.json
@@ -5,7 +5,8 @@
   "creators": [
     {
       "name": "Court, Robert",
-      "affiliation": "University of Edinburgh"
+      "affiliation": "University of Edinburgh",
+      "orcid": "0000-0002-0173-9080"
     },
     {
       "name": "Jefferis, Gregory",


### PR DESCRIPTION
Adds Robert Court's ORCID (`0000-0002-0173-9080`, University of Edinburgh) to the `.zenodo.json` creator entry, so the deposit links to his ORCID record and the output is attributed automatically.

Takes effect on the next release.