### PR TITLE
Change licence to CC BY 4.0

### DIFF
--- a/.zenodo.json
+++ b/.zenodo.json
@@ -1,7 +1,7 @@
 {
   "title": "Drosophila adult brain template JFRC2 and BrainName painted domains",
   "upload_type": "dataset",
-  "license": "cc-by-sa-4.0",
+  "license": "cc-by-4.0",
   "creators": [
     {
       "name": "Court, Robert",

--- a/LICENSE
+++ b/LICENSE
@@ -1,4 +1,4 @@
-Attribution-ShareAlike 4.0 International
+Attribution 4.0 International
 
 =======================================================================
 
@@ -54,18 +54,16 @@ exhaustive, and do not form part of our licenses.
 
 =======================================================================
 
-Creative Commons Attribution-ShareAlike 4.0 International Public
-License
+Creative Commons Attribution 4.0 International Public License
 
 By exercising the Licensed Rights (defined below), You accept and agree
 to be bound by the terms and conditions of this Creative Commons
-Attribution-ShareAlike 4.0 International Public License ("Public
-License"). To the extent this Public License may be interpreted as a
-contract, You are granted the Licensed Rights in consideration of Your
-acceptance of these terms and conditions, and the Licensor grants You
-such rights in consideration of benefits the Licensor receives from
-making the Licensed Material available under these terms and
-conditions.
+Attribution 4.0 International Public License ("Public License"). To the
+extent this Public License may be interpreted as a contract, You are
+granted the Licensed Rights in consideration of Your acceptance of
+these terms and conditions, and the Licensor grants You such rights in
+consideration of benefits the Licensor receives from making the
+Licensed Material available under these terms and conditions.
 
 
 Section 1 -- Definitions.
@@ -84,11 +82,7 @@ Section 1 -- Definitions.
      and Similar Rights in Your contributions to Adapted Material in
      accordance with the terms and conditions of this Public License.
 
-  c. BY-SA Compatible License means a license listed at
-     creativecommons.org/compatiblelicenses, approved by Creative
-     Commons as essentially the equivalent of this Public License.
-
-  d. Copyright and Similar Rights means copyright and/or similar rights
+  c. Copyright and Similar Rights means copyright and/or similar rights
      closely related to copyright including, without limitation,
      performance, broadcast, sound recording, and Sui Generis Database
      Rights, without regard to how the rights are labeled or
@@ -96,33 +90,29 @@ Section 1 -- Definitions.
      specified in Section 2(b)(1)-(2) are not Copyright and Similar
      Rights.
 
-  e. Effective Technological Measures means those measures that, in the
+  d. Effective Technological Measures means those measures that, in the
      absence of proper authority, may not be circumvented under laws
      fulfilling obligations under Article 11 of the WIPO Copyright
      Treaty adopted on December 20, 1996, and/or similar international
      agreements.
 
-  f. Exceptions and Limitations means fair use, fair dealing, and/or
+  e. Exceptions and Limitations means fair use, fair dealing, and/or
      any other exception or limitation to Copyright and Similar Rights
      that applies to Your use of the Licensed Material.
 
-  g. License Elements means the license attributes listed in the name
-     of a Creative Commons Public License. The License Elements of this
-     Public License are Attribution and ShareAlike.
-
-  h. Licensed Material means the artistic or literary work, database,
+  f. Licensed Material means the artistic or literary work, database,
      or other material to which the Licensor applied this Public
      License.
 
-  i. Licensed Rights means the rights granted to You subject to the
+  g. Licensed Rights means the rights granted to You subject to the
      terms and conditions of this Public License, which are limited to
      all Copyright and Similar Rights that apply to Your use of the
      Licensed Material and that the Licensor has authority to license.
 
-  j. Licensor means the individual(s) or entity(ies) granting rights
+  h. Licensor means the individual(s) or entity(ies) granting rights
      under this Public License.
 
-  k. Share means to provide material to the public by any means or
+  i. Share means to provide material to the public by any means or
      process that requires permission under the Licensed Rights, such
      as reproduction, public display, public performance, distribution,
      dissemination, communication, or importation, and to make material
@@ -130,13 +120,13 @@ Section 1 -- Definitions.
      public may access the material from a place and at a time
      individually chosen by them.
 
-  l. Sui Generis Database Rights means rights other than copyright
+  j. Sui Generis Database Rights means rights other than copyright
      resulting from Directive 96/9/EC of the European Parliament and of
      the Council of 11 March 1996 on the legal protection of databases,
      as amended and/or succeeded, as well as other essentially
      equivalent rights anywhere in the world.
 
-  m. You means the individual or entity exercising the Licensed Rights
+  k. You means the individual or entity exercising the Licensed Rights
      under this Public License. Your has a corresponding meaning.
 
 
@@ -182,13 +172,7 @@ Section 2 -- Scope.
                Licensed Rights under the terms and conditions of this
                Public License.
 
-            b. Additional offer from the Licensor -- Adapted Material.
-               Every recipient of Adapted Material from You
-               automatically receives an offer from the Licensor to
-               exercise the Licensed Rights in the Adapted Material
-               under the conditions of the Adapter's License You apply.
-
-            c. No downstream restrictions. You may not offer or impose
+            b. No downstream restrictions. You may not offer or impose
                any additional or different terms or conditions on, or
                apply any Effective Technological Measures to, the
                Licensed Material if doing so restricts exercise of the
@@ -270,24 +254,9 @@ following conditions.
           information required by Section 3(a)(1)(A) to the extent
           reasonably practicable.
 
-  b. ShareAlike.
-
-     In addition to the conditions in Section 3(a), if You Share
-     Adapted Material You produce, the following conditions also apply.
-
-       1. The Adapter's License You apply must be a Creative Commons
-          license with the same License Elements, this version or
-          later, or a BY-SA Compatible License.
-
-       2. You must include the text of, or the URI or hyperlink to, the
-          Adapter's License You apply. You may satisfy this condition
-          in any reasonable manner based on the medium, means, and
-          context in which You Share Adapted Material.
-
-       3. You may not offer or impose any additional or different terms
-          or conditions on, or apply any Effective Technological
-          Measures to, Adapted Material that restrict exercise of the
-          rights granted under the Adapter's License You apply.
+       4. If You Share Adapted Material You produce, the Adapter's
+          License You apply must not prevent recipients of the Adapted
+          Material from complying with this Public License.
 
 
 Section 4 -- Sui Generis Database Rights.
@@ -302,8 +271,7 @@ apply to Your use of the Licensed Material:
   b. if You include all or a substantial portion of the database
      contents in a database in which You have Sui Generis Database
      Rights, then the database in which You have Sui Generis Database
-     Rights (but not its individual contents) is Adapted Material,
-     including for purposes of Section 3(b); and
+     Rights (but not its individual contents) is Adapted Material; and
 
   c. You must comply with the conditions in Section 3(a) if You Share
      all or a substantial portion of the contents of the database.

--- a/LICENSE-NOTES.md
+++ b/LICENSE-NOTES.md
@@ -4,10 +4,10 @@ This repository holds image data, not software, and the material in it does not 
 come from the same place. The `LICENSE` file at the root states the default terms;
 the exceptions below take precedence for the files they cover.
 
-## Default: CC BY-SA 4.0
+## Default: CC BY 4.0
 
 Everything not listed under "Exceptions" is released under the Creative Commons
-Attribution-ShareAlike 4.0 International licence, matching the terms Virtual Fly
+Attribution 4.0 International licence, matching the terms Virtual Fly
 Brain publishes for the corresponding dataset, BrainName neuropils on adult brain
 JFRC2: <https://virtualflybrain.org/reports/JenettShinomya_BrainName>
 
@@ -49,3 +49,5 @@ software licence and was never an accurate description of the terms for image da
 It has been replaced rather than supplemented. Nothing in this change is intended to
 narrow any permission previously granted; anyone relying on the earlier GPL grant for
 their own prior use is unaffected.
+
+In August 2026 the licence was changed again, from CC BY-SA 4.0 to **CC BY 4.0**, to match the licence named in Virtual Fly Brain's own publication (Court et al. 2023, *Front. Physiol.* 14:1076533) and to allow deposition in EMBL-EBI archives, which accept CC0 or CC BY 4.0 but not ShareAlike. This widens permissions; it does not narrow them.


### PR DESCRIPTION
Virtual Fly Brain's own publication (Court et al. 2023, *Front. Physiol.* 14:1076533) names CC-BY-4.0 as the licence for VFB data. This repository carried CC BY-SA 4.0, applied in August 2026 to match the per-dataset terms recorded on the website.

ShareAlike also blocks deposition in the EMBL-EBI archives, which accept CC0 or CC BY 4.0 but not SA — and those are the durable homes proposed for VFB's sole-custody data.

This widens permissions rather than narrowing them. `LICENSE-NOTES.md` records the change and keeps the existing carve-outs for third-party material. Takes effect on the next release.